### PR TITLE
Request

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # KMPDownloader
 Simple Kemono.party downloader
+
+*Next Update will be delayed, working to get all the bugs sweeped up in preparation for a massive update coming afterwards.*
+
 Ran and built in Windows 10 with Visual Studios on Python 3.10
 Functionality not guaranteed until 1.0, There are known bugs!
 Can download everything from Files, save text and links in Content, and everything in Downloads. Can be set to automatically unzip files if they contain no password.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ View changelog for more details on features not included here.
 - Extraction of a work's content and comments*.
 - Queuing system, download multiple URLs without user input
 - Multhreading support, significant download speed bonus.
+- Ease of use, cookies are for eating only!  
 
 *Extraction is content is limited to text only. Hyperlinks will have their target url extracted for post content.
 


### PR DESCRIPTION
Hi, the option to keep the filenames that have the kemono links?

Example:

https://kemono.party/fanbox/user/20953275/post/1996205

First image link:

[558c.jpg](https://data5.kemono.party/data/94/62/94622dfa20b9ba0d8daba26003cde386c4cc854624327f941cbc98e102812ab6.jpg?f=cdaaf71c-dd75-44a9-a6ee-32147f39558c.jpg)

Filename: 94622dfa20b9ba0d8daba26003cde386c4cc854624327f941cbc98e102812ab6.jpg 

and exclude links or post contain words like PSD, Clip, or the  .psd or .clip?

Thanks